### PR TITLE
Custom bandits

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ run `python3 -m pytest` on linux or `pytest` on os x.
 ```
 usage: experiment.py [-h] [-g GPU] [-e EPOCHS] -p POLICY [-a ACQUISITIONS]
                      [-d DROPOUTITERATIONS] -f FOLDER [-s SEED] [-m MODEL]
-                     [-r REWARD] [-gamma GAMMA] [-policyparam POLICY_PARAM]
+                     [-r REWARD] [-data DATA] [-gamma GAMMA]
+                     [-policyparam POLICY_PARAM] [-w WEIGHT_DECAY]
+                     [-b BATCH_SIZE] [-q QUERIES]
+                     [-custom CUSTOM [CUSTOM ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -45,21 +48,37 @@ named arguments:
   -r REWARD, --reward REWARD
                         Reward to use: `marginalacc`, `marginallogp`, `logp`,
                         `acc`
+  -data DATA, --data DATA
+                        the data to use, `mnist` and `cifar10` supported.
+                        mnist is default
   -gamma GAMMA, --gamma GAMMA
                         The gamma discount factor to use
   -policyparam POLICY_PARAM, --policy-param POLICY_PARAM
                         This is either epislon or c depending on which bandit
                         policy you chose
+  -w WEIGHT_DECAY, --weight_decay WEIGHT_DECAY
+                        Weight Decay for the L2 regularizer
+  -b BATCH_SIZE, --batch_size BATCH_SIZE
+                        Batch Size
+  -q QUERIES, --queries QUERIES
+                        Queries from Pool Set
+  -custom CUSTOM [CUSTOM ...], --custom CUSTOM [CUSTOM ...]
+                        custom acquisition functions to use: Here are some
+                        defaults: 3arm-trivial: [bald, random, negative_bald]
+                        all: [] Otherwise you can access any combination of
+                        acqusition functions you want by just passing their
+                        names
 
 ```
 
 ## Available Policies
 
-1. `random`: randomly pick a different acqusition function at each round
+1. `random`: randomly pick a different acqusition function at each round (this is basically bandit that doesn't use its Q values)
 2. `uniform-maxentropy`: use `maxentropy` acquisition function for the whole experiment
 1. `uniform-segnet`: use `segnet` acquisition function for the whole experiment
 1. `uniform-bald`: use `bald` acquisition function for the whole experiment
 1. `uniform-varratio`: use `varratio` acquisition function for the whole experiment
+1. `uniform-random`: use `random` acquisition function for the whole experiment
 1. `bandit-ucb`: Use UCB to learn which acquisition functions to pick
 2. `bandit-epsilongreedy`: use epsilon greedy to learn which acquisition functions to pick
 

--- a/src/policies.py
+++ b/src/policies.py
@@ -128,7 +128,10 @@ class UCBBanditPolicy(BanditPolicy):
 
 
 def policy_parser(policy_name, args):
-    from src.acquisition_function import ACQUISITION_FUNCTIONS_TEXT
+    from src.acquisition_function import (
+            ACQUISITION_FUNCTIONS_TEXT,
+            ACQUISITION_FUNCTIONS_BANDIT_TEST
+        )
     if policy_name == 'random':
         print('Random policy where at every step we pick randomly from ')
         print(ACQUISITION_FUNCTIONS_TEXT)
@@ -142,16 +145,25 @@ def policy_parser(policy_name, args):
         return UniformPolicy([acquisition_function])
 
     elif policy_name.startswith('bandit-'):
+
+        if 'all' in args.custom:
+            available_acqs = ACQUISITION_FUNCTIONS_TEXT
+        elif '3arm-trivial' in args.custom:
+            available_acqs = ACQUISITION_FUNCTIONS_BANDIT_TEST
+        else:
+            assert set(args.custom).issubset(set(ACQUISITION_FUNCTIONS_TEXT)), \
+                'Note that custom acquisition functions must be a subset of all acqusition functions available'
+            available_acqs = args.custom
         print('At every step we pick actions from ')
-        print(ACQUISITION_FUNCTIONS_TEXT)
+        print(available_acqs)
         policy = policy_name.replace('bandit-', '')
         print('according to a policy')
         print(policy)
         if policy == 'ucb':
-            return UCBBanditPolicy(ACQUISITION_FUNCTIONS_TEXT,
+            return UCBBanditPolicy(available_acqs,
                                    gamma=args.gamma,
                                    c=args.policy_param)
         elif policy == 'epsilongreedy':
-            return EpsilonGreedyBanditPolicy(ACQUISITION_FUNCTIONS_TEXT,
+            return EpsilonGreedyBanditPolicy(available_acqs,
                                              gamma=args.gamma,
                                              epsilon=args.policy_param)

--- a/src/utils.py
+++ b/src/utils.py
@@ -85,13 +85,12 @@ def get_parser():
             help="""
                custom acquisition functions to use:
                Here are some defaults:
-                  3 arm trivial: [bald, random, negative_bald]
+                  3arm-trivial: [bald, random, negative_bald]
                   all: [] 
-
                Otherwise you can access any combination 
-               of acqusition functions you want
+               of acqusition functions you want by just passing their names
             """,
-            required=False, nargs='+' type=str, default='all')      
+            required=False, nargs='+', type=str, default='all')      
             
       return parser
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -79,8 +79,20 @@ def get_parser():
       
       named_args.add_argument('-q', '--queries',
             help="""Queries from Pool Set""",
-            required=False, type=int, default=10)      
-      
+            required=False, type=int, default=10)   
+
+      named_args.add_argument('-custom', '--custom',
+            help="""
+               custom acquisition functions to use:
+               Here are some defaults:
+                  3 arm trivial: [bald, random, negative_bald]
+                  all: [] 
+
+               Otherwise you can access any combination 
+               of acqusition functions you want
+            """,
+            required=False, nargs='+' type=str, default='all')      
+            
       return parser
 
 


### PR DESCRIPTION
Ability to change the arms of the bandit at will.

There are two presets:

1. `all` (default) which uses all the available acquisition functions
2. `3arm-trivial` which uses `BALD, RANDOM, and NEGATIVE_BALD` as the three arms, you should eventually find that the bandit stops using NEGATIVE_BALD
3

Any other combination can be given by
```
--custom random random bald maxentropy
```
